### PR TITLE
Vendor openssl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 # Based on the "trust" template v0.1.2
 # https://github.com/japaric/trust/tree/v0.1.2
-
-dist: trusty
 language: rust
 services: docker
 sudo: required
@@ -17,6 +15,7 @@ matrix:
     - env: TARGET=arm-unknown-linux-gnueabi NO_EXEC_TESTS=1
     - env: TARGET=armv7-unknown-linux-gnueabihf NO_EXEC_TESTS=1
     - env: TARGET=mips-unknown-linux-gnu NO_EXEC_TESTS=1
+    - env: TARGET=i686-unknown-linux-gnu
     - env: TARGET=x86_64-unknown-linux-gnu DEBIAN_PACKAGING=1
     - env: TARGET=x86_64-unknown-linux-musl RUSTLS=1 DEBIAN_PACKAGING=1
       addons:
@@ -27,12 +26,10 @@ matrix:
     - env: TARGET=x86_64-apple-darwin
       os: osx
 
-    # *BSD
-    - env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
-
     # Testing other channels
     - rust: nightly
     - rust: beta
+    - rust: stable
 
 before_install:
   - set -e
@@ -67,7 +64,7 @@ deploy:
     # In this example, there are some targets that are tested using the stable
     # and nightly channels. This condition makes sure there is only one release
     # for such targets and that's generated using the stable channel
-    condition: $TRAVIS_RUST_VERSION = stable
+    condition: "$TRAVIS_RUST_VERSION = stable && -n $TARGET"
     tags: true
   provider: releases
   skip_cleanup: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,7 @@ dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rouille 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -929,6 +930,14 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "openssl-src"
+version = "111.6.1+1.1.1d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,6 +945,7 @@ dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-src 111.6.1+1.1.1d (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2306,6 +2316,7 @@ dependencies = [
 "checksum num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72"
 "checksum openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)" = "3a3cc5799d98e1088141b8e01ff760112bbd9f19d850c124500566ca6901a585"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+"checksum openssl-src 111.6.1+1.1.1d (registry+https://github.com/rust-lang/crates.io-index)" = "c91b04cb43c1a8a90e934e0cd612e2a5715d976d2d6cff4490278a0cddf35005"
 "checksum openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)" = "465d16ae7fc0e313318f7de5cecf57b2fbe7511fd213978b457e1c96ff46736f"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ toml = "0.5"
 structopt = "0.3.9"
 chrono = "0.4"
 tokio = { version = "0.2", features = ["rt-core", "macros"] }
+openssl = { version = '0.10', optional = true }
 
 [dependencies.serde]
 version = "1.0"
@@ -29,6 +30,7 @@ features = ["serde"]
 
 [features]
 default = ["reqwest/default-tls", "trust-dns-resolver/dns-over-native-tls"]
+vendored-openssl = ["openssl/vendored"]
 rustls = ["reqwest/rustls-tls", "trust-dns-resolver/dns-over-rustls"]
 
 # Disable logging timestamp info (ie: the humantime feature) as mechanisms like

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -28,6 +28,8 @@ main() {
 
     if [ -n "$RUSTLS" ]; then
         CARGO_FLAGS="$CARGO_FLAGS --no-default-features --features rustls"
+    elif [ -n "$TARGET" ]; then
+        CARGO_FLAGS="$CARGO_FLAGS --features vendored-openssl"
     fi
 
     $CARGO_CMD rustc $CARGO_FLAGS --bin dness --release -- -C lto

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -16,6 +16,8 @@ main() {
 
     if [ -n "$RUSTLS" ]; then
         CARGO_FLAGS="$CARGO_FLAGS --no-default-features --features rustls"
+    elif [ -n "$TARGET" ]; then
+        CARGO_FLAGS="$CARGO_FLAGS --features vendored-openssl"
     fi
 
     $CARGO_CMD build $CARGO_FLAGS --all


### PR DESCRIPTION
Since cross 0.2, openssl is no longer bundled into the images that cross uses for compilation. This causes failures in builds that assumed its presence.

While I see others ditching openssl for rustls or pinning cross to a previous version, there is a less drastic approach, as not every library is compatible with rustls (eg: rust-postgres) and pinning is a short term solution. We can fix the issue by adding an opt-in feature (eg: `vendored-openssl`) that statically compiles openssl into the binary. It's even possible for the application to have three ways to be built for a linux target:

- Dynamically link to openssl using native-tls (the default)
- Statically link openssl
- Statically link rustls

Below is a partial Cargo.toml snippet where we include openssl as an optional feature alongside optional rustls.

```toml
[dependencies]
openssl = { version = '0.10', optional = true }

[features]
default = ["reqwest/default-tls", "trust-dns-resolver/dns-over-native-tls"]
vendored-openssl = ["openssl/vendored"]
rustls = ["reqwest/rustls-tls", "trust-dns-resolver/dns-over-rustls"]
```

So now we can create the following builds

```
# dynamically linked
cargo build

# statically link in openssl (still dynamically linked to libc)
cargo build --features vendored-openssl

# compile with rustls
cargo build --no-default-features --features rustls

# static build with openssl
cross build --target x86_64-unknown-linux-musl  --features vendored-openssl

# static build with rustls
cross build --target x86_64-unknown-linux-musl --no-default-features --features rustls
```

There's a bit of a precedence of writing cargo configs that vendor openssl, as that is what tools like [wasm-pack](https://github.com/rustwasm/wasm-pack/blob/9209df9862a4198b092e37bf44f81be25b4aafc7/Cargo.toml#L24) and [vector](https://github.com/timberio/vector/blob/aa523b00977c89a44d7cbb17e7e7d0bf3e179c1a/Cargo.toml#L190) use to distribute their executables. This means that all executables for non-macos and non-windows systems (as they should rely on native-tls functionality) will be include a crypto library (openssl or rustls) that is statically linked.

Due note that there is a slight downside to this approach in that it may seem wonky to select both features:

```
cargo build --features vendored-openssl --features rustls
```

But this problem seems avoidable.

I did need to remove netbsd platform as a target as I couldn't get [openssl-src](https://github.com/alexcrichton/openssl-src-rs) to compile for it. This is not a deal breaker for me. On the plus side I was able to add 32bit linux support