### PR TITLE
Introduce alternative WAN ip resolvers

### DIFF
--- a/assets/ipify-config.toml
+++ b/assets/ipify-config.toml
@@ -1,0 +1,1 @@
+ip_resolver = "ipify"

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,14 +40,31 @@ impl fmt::Display for ConfigError {
     }
 }
 
-#[derive(Deserialize, Clone, PartialEq, Debug, Default)]
+#[derive(Deserialize, Clone, PartialEq, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct DnsConfig {
+    #[serde(default = "default_resolver")]
+    pub ip_resolver: String,
+
     #[serde(default)]
     pub log: LogConfig,
 
     #[serde(default)]
     pub domains: Vec<DomainConfig>,
+}
+
+fn default_resolver() -> String {
+    String::from("opendns")
+}
+
+impl Default for DnsConfig {
+    fn default() -> Self {
+        DnsConfig {
+            ip_resolver: default_resolver(),
+            log: Default::default(),
+            domains: Default::default(),
+        }
+    }
 }
 
 #[derive(Deserialize, Clone, PartialEq, Debug)]
@@ -151,6 +168,7 @@ mod tests {
         assert_eq!(
             config,
             DnsConfig {
+                ip_resolver: String::from("opendns"),
                 log: LogConfig {
                     level: LevelFilter::Info,
                 },
@@ -173,6 +191,7 @@ mod tests {
         assert_eq!(
             config,
             DnsConfig {
+                ip_resolver: String::from("opendns"),
                 log: LogConfig {
                     level: LevelFilter::Info,
                 },
@@ -224,6 +243,7 @@ mod tests {
         assert_eq!(
             config,
             DnsConfig {
+                ip_resolver: String::from("opendns"),
                 log: LogConfig {
                     level: LevelFilter::Debug,
                 },
@@ -244,6 +264,22 @@ mod tests {
                         ]
                     })
                 ]
+            }
+        );
+    }
+
+    #[test]
+    fn deserialize_ipify_config() {
+        let toml_str = &include_str!("../assets/ipify-config.toml");
+        let config: DnsConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config,
+            DnsConfig {
+                ip_resolver: String::from("ipify"),
+                log: LogConfig {
+                    level: LevelFilter::Info,
+                },
+                domains: vec![]
             }
         );
     }

--- a/src/namecheap.rs
+++ b/src/namecheap.rs
@@ -2,7 +2,7 @@ use crate::config::NamecheapConfig;
 use crate::core::Updates;
 use crate::dns::DnsResolver;
 use crate::errors::DnessError;
-use log::{warn, info};
+use log::{info, warn};
 use std::net::Ipv4Addr;
 
 #[derive(Debug)]
@@ -79,7 +79,10 @@ pub async fn update_domains(
                     results.current += 1;
                 } else {
                     namecheap.update_domain(record, wan).await?;
-                    info!("{} from domain {} updated from {} to {}", record, config.domain, ip, wan);
+                    info!(
+                        "{} from domain {} updated from {} to {}",
+                        record, config.domain, ip, wan
+                    );
                     results.updated += 1;
                 }
             }


### PR DESCRIPTION
Previously it wasn't possible to configure dness to use an alternative
ip resolver other than opendns. This has worked fine for the most part,
but some users are reporting that the opendns method doesn't work on
their networks. The fix is to introduce configuration so that the user
can pick amongst ip resolvers. The default will continue to be opendns,
but now ipify is available. One can opt into using ipify by adding the
following to the top of their config

```toml
ip_resolver = "ipify"
```

Closes #184 