### PR TITLE
Fix an environment variable typo

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -7,7 +7,7 @@ main() {
     CARGO_FLAGS=""
 
     if [ -n "$TARGET" ]; then
-        CARGO_FLAGS="$CARGO_FLAG --target $TARGET"
+        CARGO_FLAGS="$CARGO_FLAGS --target $TARGET"
     fi
 
     if [ -n "$TARGET" ]; then


### PR DESCRIPTION
It didn't directly affect me so I can't be 100% sure but it looks like this typo might catch out some people trying certain build configurations.