### PR TITLE
Print root cause of errors when they occur

### DIFF
--- a/src/cloudflare.rs
+++ b/src/cloudflare.rs
@@ -83,7 +83,7 @@ pub enum ClErrorKind {
 }
 
 impl error::Error for ClError {
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self.kind {
             ClErrorKind::SendHttp(_, ref e) => Some(e),
             ClErrorKind::DecodeHttp(_, ref e) => Some(e),

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,7 @@ pub enum ConfigErrorKind {
 }
 
 impl error::Error for ConfigError {
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self.kind {
             ConfigErrorKind::FileNotFound(ref e) => Some(e),
             ConfigErrorKind::Misread(ref e) => Some(e),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -77,7 +77,7 @@ impl From<DnsError> for DnessError {
 }
 
 impl error::Error for DnessError {
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self.kind {
             DnessErrorKind::SendHttp { ref source, .. } => Some(source),
             DnessErrorKind::BadResponse { ref source, .. } => Some(source),
@@ -125,7 +125,7 @@ pub enum DnsErrorKind {
 }
 
 impl error::Error for DnsError {
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self.kind {
             DnsErrorKind::DnsCreation(ref e) => Some(e),
             DnsErrorKind::DnsResolve(ref e) => Some(e),


### PR DESCRIPTION
Previously dness had error implementations that did not implement
`std::error::Error::source` which caused the root error to not print
it's message -- giving bad error messages.

Before:

```
[ERROR dness] could not configure application from: dness.conf
        caused by: config issue: a parsing error
```

After:

```
[ERROR dness] could not configure application from: dness.conf
        caused by: config issue: a parsing error
        caused by: unknown field `token`, expected one of `email`, `key`, `zone`, `records` for key `domains` at line 37 column 1
```