### PR TITLE
Include debug statement on cloudflare update dns

### DIFF
--- a/src/cloudflare.rs
+++ b/src/cloudflare.rs
@@ -293,6 +293,11 @@ impl<'a> CloudflareClient<'a> {
             self.zone_id, record.id
         );
 
+        debug!(
+            "{} from zone {} updating from {} to {}: {}",
+            record.name, self.zone_name, record.content, addr, &url
+        );
+
         let update = CloudflareDnsRecordUpdate {
             content: addr.to_string(),
         };


### PR DESCRIPTION
When there is an error when updating a cloudflare dns entry, show a
debug entry with the url that will be requested. This url contains the
resolved record id, so one can more easily construct a curl command to
inspect why the request failed.