### PR TITLE
Allow omitting unused cloudflare auth fields from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,27 +82,52 @@ Sample output:
 [INFO  dness] processed all: (updated: 0, already current: 0, missing: 0) in 29ms
 ```
 
-### Sample Configuration
+### Simple Configuration
 
-But dness can do more than resolve one's WAN IP. Below is a sample configuration (dness.conf) that should cover most needs:
+But dness can do more than resolve one's WAN IP. Below is a simple configuration file (conventionally named `dness.conf`) that will update cloudflare records.
+
+```toml
+[[domains]]
+type = "cloudflare"
+token = "dec0de"
+zone = "example.com"
+records = [
+    "n.example.com"
+]
+```
+
+Execute dness with the configuration:
+
+```
+./dness -c dness.conf
+```
+
+### Annotated Configuration
+
+Below are the configuration options, but they've been annotated with comments.
 
 ```toml
 [log]
 # How verbose the log is. Common values: Error, Warn, Info, Debug, Trace
 # The default level is info
-level = "Info"
+level = "Debug"
 
 [[domains]]
 # We denote that our domain is managed by cloudflare
 type = "cloudflare"
 
+# Create Cloudflare token by using the use "Edit zone DNS" API token template.
+# Alternatively one can use email + key fields but the token is recommended as
+# it is more secure
+token = "dec0de"
+
 # The email address registered in cloudflare that is authorized to update dns
-# records
-email = "admin@example.com"
+# records. Only required when not using the token field
+# email = "admin@example.com"
 
 # The cloudflare key can be found in the domain overview, in "Get your API key"
-# and view "Global API Key" (or another key as appropriate)
-key = "deadbeef"
+# and view "Global API Key". Required when "email" is used
+# key = "deadbeef"
 
 # The zone is the domain name
 zone = "example.com"
@@ -122,12 +147,6 @@ records = [
     "n.example2.com",
     "n2.example2.com"
 ]
-```
-
-Execute with configuration:
-
-```
-./dness -c dness.conf
 ```
 
 ### Supported Dynamic DNS Services

--- a/assets/base-config.toml
+++ b/assets/base-config.toml
@@ -1,8 +1,6 @@
 [[domains]]
 type = "cloudflare"
-email = "a@b.com"
-key = "deadbeef"
-token = "deadbeef"
+token = "dec0de"
 zone = "example.com"
 records = [
     "n.example.com"

--- a/assets/readme-config.toml
+++ b/assets/readme-config.toml
@@ -1,26 +1,24 @@
 [log]
-# How verbose the log is. Commons values are Error, Warn, Info, Debug, Trace
+# How verbose the log is. Common values: Error, Warn, Info, Debug, Trace
+# The default level is info
 level = "Debug"
 
 [[domains]]
 # We denote that our domain is managed by cloudflare
 type = "cloudflare"
 
-# Generate a cloudflare token with suitable access to the zone in your profile.
-# https://dash.cloudflare.com/profile/api-tokens
-# Required if "email" and "key" are not defined
-# !!! Using a token is more secure than using an email and key !!!
-token = "deadbeef"
+# Create Cloudflare token by using the use "Edit zone DNS" API token template.
+# Alternatively one can use email + key fields but the token is recommended as
+# it is more secure
+token = "dec0de"
 
 # The email address registered in cloudflare that is authorized to update dns
-# records
-# Required if "token" is not defined
-email = "admin@example.com"
+# records. Only required when not using the token field
+# email = "admin@example.com"
 
 # The cloudflare key can be found in the domain overview, in "Get your API key"
-# and view "Global API Key" (or another key as appropriate)
-# Required if "token" is not defined
-key = "deadbeef"
+# and view "Global API Key". Required when "email" is used
+# key = "deadbeef"
 
 # The zone is the domain name
 zone = "example.com"
@@ -35,7 +33,6 @@ records = [
 type = "cloudflare"
 email = "admin@example.com"
 key = "deadbeef"
-token = "deadbeef"
 zone = "example2.com"
 records = [
     "n.example2.com",

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,9 +108,9 @@ impl DomainConfig {
 #[derive(Deserialize, Clone, PartialEq, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct CloudflareConfig {
-    pub email: String,
-    pub key: String,
-    pub token: String,
+    pub email: Option<String>,
+    pub key: Option<String>,
+    pub token: Option<String>,
     pub zone: String,
     pub records: Vec<String>,
 }
@@ -197,9 +197,9 @@ mod tests {
                     level: LevelFilter::Info,
                 },
                 domains: vec![DomainConfig::Cloudflare(CloudflareConfig {
-                    email: String::from("a@b.com"),
-                    key: String::from("deadbeef"),
-                    token: String::from("deadbeef"),
+                    email: None,
+                    key: None,
+                    token: Some(String::from("dec0de")),
                     zone: String::from("example.com"),
                     records: vec![String::from("n.example.com")]
                 })]
@@ -251,16 +251,16 @@ mod tests {
                 },
                 domains: vec![
                     DomainConfig::Cloudflare(CloudflareConfig {
-                        email: String::from("admin@example.com"),
-                        key: String::from("deadbeef"),
-                        token: String::from("deadbeef"),
+                        email: None,
+                        key: None,
+                        token: Some(String::from("dec0de")),
                         zone: String::from("example.com"),
                         records: vec![String::from("n.example.com")]
                     }),
                     DomainConfig::Cloudflare(CloudflareConfig {
-                        email: String::from("admin@example.com"),
-                        key: String::from("deadbeef"),
-                        token: String::from("deadbeef"),
+                        email: Some(String::from("admin@example.com")),
+                        key: Some(String::from("deadbeef")),
+                        token: None,
                         zone: String::from("example2.com"),
                         records: vec![
                             String::from("n.example2.com"),


### PR DESCRIPTION
Previously, while specifying a cloudflare token was the preferred
mechanism for authorization, one still had to provide values (albeit
blank) for key and email. Vice versa as well (using key and email would
require at least an unused blank for token).

This PR solves this by denoting that these fields are optional. Now they
can be entirely omitted from the config if unused.

This commit also continues upon work done by @luckyrat by extracting
authorization into a trait and passing around trait objects whenever a
request needs authorization.

I've confirmed that this work and have switched my setup to use
cloudflare tokens over email + key

This change didn't take me as long as I had suspected and I'll cut a
minor release, soonish, within a week.