### PR TITLE
Add noip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,16 @@ records = [ "@", "sub" ]
 
 [he.net](http://he.net/) follows the same flow as Namecheap (check the current record via DNS and update if necessary).
 
+### No-Ip
+
+```toml
+[[domains]]
+type = "noip"
+hostname = "dnesstest.hopto.org"
+username = "myemail@example.org"
+password = "super_secret_password"
+```
+
 ### Supported WAN IP Resolvers
 
 There are a couple different methods for dness to resolve the WAN IP address.

--- a/assets/noip-config.toml
+++ b/assets/noip-config.toml
@@ -1,0 +1,4 @@
+type = "noip"
+hostname = "dnesstest.hopto.org"
+username = "myemail@example.org"
+password = "super_secret_password"

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,6 +101,7 @@ pub enum DomainConfig {
     GoDaddy(GoDaddyConfig),
     Namecheap(NamecheapConfig),
     He(HeConfig),
+    NoIp(NoIpConfig),
 }
 
 impl DomainConfig {
@@ -110,6 +111,7 @@ impl DomainConfig {
             DomainConfig::GoDaddy(c) => format!("{} ({})", c.domain, "godaddy"),
             DomainConfig::Namecheap(c) => format!("{} ({})", c.domain, "namecheap"),
             DomainConfig::He(c) => format!("{} ({})", c.hostname, "he"),
+            DomainConfig::NoIp(c) => format!("{} ({})", c.hostname, "noip"),
         }
     }
 }
@@ -155,6 +157,16 @@ pub struct HeConfig {
     pub records: Vec<String>,
 }
 
+#[derive(Deserialize, Clone, PartialEq, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct NoIpConfig {
+    #[serde(default = "noip_base_url")]
+    pub base_url: String,
+    pub username: String,
+    pub password: String,
+    pub hostname: String,
+}
+
 fn godaddy_base_url() -> String {
     String::from("https://api.godaddy.com")
 }
@@ -165,6 +177,10 @@ fn namecheap_base_url() -> String {
 
 fn he_base_url() -> String {
     String::from("https://dyn.dns.he.net")
+}
+
+fn noip_base_url() -> String {
+    String::from("https://dynupdate.no-ip.com")
 }
 
 pub fn parse_config<P: AsRef<Path>>(path: P) -> Result<DnsConfig, ConfigError> {
@@ -347,6 +363,21 @@ mod tests {
                 },
                 domains: vec![]
             }
+        );
+    }
+
+    #[test]
+    fn deserialize_noip_config() {
+        let toml_str = &include_str!("../assets/noip-config.toml");
+        let config: DomainConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config,
+            DomainConfig::NoIp(NoIpConfig {
+                base_url: noip_base_url(),
+                username: String::from("myemail@example.org"),
+                hostname: String::from("dnesstest.hopto.org"),
+                password: String::from("super_secret_password"),
+            })
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod errors;
 mod godaddy;
 mod he;
 mod namecheap;
+mod noip;
 
 use crate::config::{parse_config, DnsConfig, DomainConfig};
 use crate::core::Updates;
@@ -135,6 +136,9 @@ async fn update_provider(
                 .map_err(|e| e.into())
         }
         DomainConfig::He(domain_config) => he::update_domains(http_client, domain_config, addr)
+            .await
+            .map_err(|e| e.into()),
+        DomainConfig::NoIp(domain_config) => noip::update_domains(http_client, domain_config, addr)
             .await
             .map_err(|e| e.into()),
     }

--- a/src/noip.rs
+++ b/src/noip.rs
@@ -1,0 +1,134 @@
+use crate::{config::NoIpConfig, core::Updates, dns::DnsResolver, errors::DnessError};
+use log::{info, warn};
+use std::net::Ipv4Addr;
+
+#[derive(Debug)]
+pub struct NoIpProvider<'a> {
+    client: &'a reqwest::Client,
+    config: &'a NoIpConfig,
+}
+
+impl<'a> NoIpProvider<'a> {
+    /// https://www.noip.com/integrate/request
+    pub async fn update_domain(&self, wan: Ipv4Addr) -> Result<(), DnessError> {
+        let base = self.config.base_url.trim_end_matches('/').to_string();
+        let get_url = format!("{}/nic/update", base);
+        let response = self
+            .client
+            .get(&get_url)
+            .query(&[
+                ("hostname", &self.config.hostname),
+                ("myip", &wan.to_string()),
+            ])
+            .basic_auth(&self.config.username, Some(&self.config.password))
+            .send()
+            .await
+            .map_err(|e| DnessError::send_http(&get_url, "noip update", e))?
+            .error_for_status()
+            .map_err(|e| DnessError::bad_response(&get_url, "noip update", e))?
+            .text()
+            .await
+            .map_err(|e| DnessError::deserialize(&get_url, "noip update", e))?;
+
+        if !response.contains("good") {
+            Err(DnessError::message(format!(
+                "expected zero errors, but received: {}",
+                response
+            )))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+pub async fn update_domains(
+    client: &reqwest::Client,
+    config: &NoIpConfig,
+    wan: Ipv4Addr,
+) -> Result<Updates, DnessError> {
+    let resolver = DnsResolver::create_cloudflare().await?;
+    let dns_query = format!("{}.", &config.hostname);
+    let response = resolver.ipv4_lookup(&dns_query).await;
+    let provider = NoIpProvider { config, client };
+    match response {
+        Ok(ip) => {
+            if ip == wan {
+                Ok(Updates {
+                    current: 1,
+                    ..Updates::default()
+                })
+            } else {
+                provider.update_domain(wan).await?;
+                info!("{} updated from {} to {}", config.hostname, ip, wan);
+                Ok(Updates {
+                    updated: 1,
+                    ..Updates::default()
+                })
+            }
+        }
+        Err(e) => {
+            // Could be a network issue or it could be that the record didn't exist.
+            warn!(
+                "resolving noip ({}) encountered an error: {}",
+                config.hostname, e
+            );
+            Ok(Updates {
+                missing: 1,
+                ..Updates::default()
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! noip_server {
+        () => {{
+            use rouille::Response;
+            use rouille::Server;
+
+            let server = Server::new("localhost:0", |request| match request.url().as_str() {
+                "/nic/update" => Response::from_data("text/plain", b"good 2.2.2.2".to_vec()),
+                _ => Response::empty_404(),
+            })
+            .unwrap();
+
+            let (tx, rx) = std::sync::mpsc::sync_channel(1);
+            let addr = server.server_addr().clone();
+            std::thread::spawn(move || {
+                while let Err(_) = rx.try_recv() {
+                    server.poll();
+                    std::thread::sleep(std::time::Duration::from_millis(50))
+                }
+            });
+            (tx, addr)
+        }};
+    }
+
+    #[tokio::test]
+    async fn test_noip_update() {
+        let (tx, addr) = noip_server!();
+        let http_client = reqwest::Client::new();
+        let new_ip = Ipv4Addr::new(2, 2, 2, 2);
+        let config = NoIpConfig {
+            base_url: format!("http://{}", addr),
+            hostname: String::from("example.com"),
+            username: String::from("me@example.com"),
+            password: String::from("my-pass"),
+        };
+
+        let summary = update_domains(&http_client, &config, new_ip).await.unwrap();
+        tx.send(()).unwrap();
+
+        assert_eq!(
+            summary,
+            Updates {
+                current: 0,
+                updated: 1,
+                missing: 0,
+            }
+        );
+    }
+}


### PR DESCRIPTION
One can specify a noip address like:

```toml
[[domains]]
type = "noip"
hostname = "dnesstest.hopto.org"
username = "myemail@example.org"
password = "super_secret_password"
```

I haven't figured out NoIP's UI to add a subdomain, so I'm not sure how
it effects the API. At the very least one could specify multiple domains
entries as a workaround.

Closes #274 