### PR TITLE
Update deb packaging to make conffiles absolute paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,9 +54,9 @@ features = ["vendored-openssl"]
 provides = "dness"
 conflicts = "dness-musl"
 assets = [
-    ["target/release/dness", "usr/bin/dness", "755"],
-    ["assets/bare-config.toml", "etc/dness/dness.conf", "644"],
-    ["assets/dness.service", "etc/systemd/system/dness.service", "644"],
-    ["assets/dness.timer", "etc/systemd/system/dness.timer", "644"]
+    ["target/release/dness", "/usr/bin/dness", "755"],
+    ["assets/bare-config.toml", "/etc/dness/dness.conf", "644"],
+    ["assets/dness.service", "/etc/systemd/system/dness.service", "644"],
+    ["assets/dness.timer", "/etc/systemd/system/dness.timer", "644"]
 ]
-conf-files = ["etc/dness/dness.conf", "etc/dness/dness.env"]
+conf-files = ["etc/dness/dness.conf", "/etc/dness/dness.env"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,9 +54,9 @@ features = ["vendored-openssl"]
 provides = "dness"
 conflicts = "dness-musl"
 assets = [
-    ["target/release/dness", "/usr/bin/dness", "755"],
-    ["assets/bare-config.toml", "/etc/dness/dness.conf", "644"],
-    ["assets/dness.service", "/etc/systemd/system/dness.service", "644"],
-    ["assets/dness.timer", "/etc/systemd/system/dness.timer", "644"]
+    ["target/release/dness", "usr/bin/dness", "755"],
+    ["assets/bare-config.toml", "etc/dness/dness.conf", "644"],
+    ["assets/dness.service", "etc/systemd/system/dness.service", "644"],
+    ["assets/dness.timer", "etc/systemd/system/dness.timer", "644"]
 ]
-conf-files = ["etc/dness/dness.conf", "/etc/dness/dness.env"]
+conf-files = ["/etc/dness/dness.conf", "/etc/dness/dness.env"]


### PR DESCRIPTION
Starting with dpkg 1.20.1, dpkg will fail to install packages that don't use absolute pathnames for conffiles. Ubuntu 21.04 is a distro that is effected by this change. Update our packaging so that it is installable on Ubuntu 21.04

Closes  #277