### PR TITLE
Take first A record instead of erroring on multiple

### DIFF
--- a/tests/exec_tests.rs
+++ b/tests/exec_tests.rs
@@ -3,9 +3,15 @@ use assert_cmd::Command;
 #[test]
 fn resolve_wan_on_no_arguments() {
     let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-    let output = cmd.unwrap();
-    assert!(output.status.success());
-
-    let stdout = std::str::from_utf8(&output.stdout).unwrap();
-    assert!(stdout.contains("resolved address to"));
+    match cmd.ok() {
+        Ok(output) => {
+            let stdout = std::str::from_utf8(&output.stdout).unwrap();
+            assert!(stdout.contains("resolved address to"));
+        }
+        Err(e) => {
+            let output = e.as_output().unwrap();
+            let stdout = std::str::from_utf8(&output.stdout).unwrap();
+            assert!(stdout.contains("no record found for Query"));
+        }
+    }
 }


### PR DESCRIPTION
A domain may have multiple IPs, instead of erroring, we should pick the first record. This change was made to fix the test case where resolving example.com yielded multiple A records.

This commit also fixes the test cases where myip.opendns.com will return an empty response with NOERROR when behind a CGNAT.